### PR TITLE
Removed not correct code

### DIFF
--- a/src/main/java/ch/bildspur/artnet/packets/ArtTimePacket.java
+++ b/src/main/java/ch/bildspur/artnet/packets/ArtTimePacket.java
@@ -14,8 +14,6 @@ public class ArtTimePacket extends ArtNetPacket {
     private int hours;
     private int type;
     
-    public long encoded;
-    
     public ArtTimePacket() {
         super(PacketType.ART_TIMECODE);
         setData(new byte[19]);
@@ -32,133 +30,21 @@ public class ArtTimePacket extends ArtNetPacket {
         minutes = data.getInt8(16);
         hours = data.getInt8(17);
         type = data.getInt8(18);
-        encoded = encode(hours, minutes, seconds, frames, type);
         return true;
     }
     
     /**
-     * Increment the timecode by 1.
+     * Set the time in one method.
+     * @param hour hours
+     * @param min minutes
+     * @param sec seconds
+     * @param frame frames
      */
-    public void increment() {
-        encoded++;
-        int[] val = decode(encoded, type);
-        frames = val[3];
-        seconds = val[2];
-        minutes = val[1];
-        hours = val[0];
-        updateData();
-    }
-    
-    /**
-     * Decrement the timecode by 1;
-     */
-    public void decrement() {
-        encoded--;
-        int[] val = decode(encoded, type);
-        frames = val[3];
-        seconds = val[2];
-        minutes = val[1];
-        hours = val[0];
-        updateData();
-    }
-    
-    /**
-     * Convert the separate values into one long value, for easy increment/decrement
-     * 
-     * @param hour number of hours
-     * @param min number of minutes
-     * @param sec number of seconds
-     * @param frame number of frames
-     * @param frameType the type of the timecode
-     * @return the encoded time value
-     */
-    public long encode(int hour, int min, int sec, int frame, int frameType) {
-        int framerate = 30;
-        switch (frameType) {
-            case 0:
-            	//film
-                framerate = 24;
-                break;
-            case 1:
-            	//ebu
-                framerate = 25;
-                break;
-            case 2:
-            	//df
-                throw new IllegalArgumentException("DF type not implemented! Do you wanna implement it yourself?");
-            case 3:
-            	//smtpe
-                framerate = 30;
-                break;
-            default:
-                framerate = 30;
-                break;
-        }
-        
-        int hour_fr = hour * 60 * 60 * framerate;
-        int min_fr = min * 60 * framerate;
-        int sec_fr = sec * framerate;
-        
-        return hour_fr + min_fr + sec_fr + frame;
-    }
-    
-    /**
-     * Decodes the encoded timecode value.<br>
-     * Elements of the returning int array:<br>
-     * 0: hour<br>
-     * 1: minute<br>
-     * 2: second<br>
-     * 3: frame<br>
-     * 
-     * @param frames the encoded time data
-     * @param frameType the type of the timecode
-     * @return the decoded time values
-     */
-    public int[] decode(long frames, int frameType) {
-        int framerate = 30;
-        switch (frameType) {
-            case 0:
-                framerate = 24;
-                break;
-            case 1:
-                framerate = 25;
-                break;
-            case 2:
-                throw new IllegalArgumentException("DF type not implemented! Do you wanna implement it yourself?");
-            case 3:
-                framerate = 30;
-                break;
-            default:
-                framerate = 30;
-                break;
-        }
-        
-        int[] dec = new int[4];
-        
-        int hour = ((int) frames / 60 / 60 / framerate);
-        frames = frames - (hour * 60 * 60 * framerate);
-        dec[0] = hour;
-        
-        int min = ((int) frames / 60 / framerate);
-        frames = frames - (min * 60 * framerate);
-        dec[1] = min;
-        
-        int sec = ((int) frames / framerate);
-        frames = frames - (sec * framerate);
-        dec[2] = sec;
-        
-        int frame = (int) frames;
-        dec[3] = frame;
-        
-        return dec;
-    }
-    
     public void setTime(int hour, int min, int sec, int frame) {
     	this.hours = hour;
     	this.minutes = min;
     	this.seconds = sec;
     	this.frames = frame;
-    	this.encoded = encode(hours, minutes, seconds, frames, type);
     	updateData();
     }
 
@@ -171,8 +57,7 @@ public class ArtTimePacket extends ArtNetPacket {
 
     
     public void setFrames(int frames) {
-        this.frames = frames & 0x0f;
-        this.encoded = encode(hours, minutes, seconds, this.frames, type);
+        this.frames = frames;
         updateData();
     }
 
@@ -186,7 +71,6 @@ public class ArtTimePacket extends ArtNetPacket {
     
     public void setSeconds(int seconds) {
         this.seconds = seconds;
-        this.encoded = encode(hours, minutes, this.seconds, frames, type);
         updateData();
     }
 
@@ -200,7 +84,6 @@ public class ArtTimePacket extends ArtNetPacket {
     
     public void setMinutes(int minutes) {
         this.minutes = minutes;
-        this.encoded = encode(hours, this.minutes, seconds, frames, type);
         updateData();
     }
 
@@ -214,12 +97,11 @@ public class ArtTimePacket extends ArtNetPacket {
     
     public void setHours(int hours) {
         this.hours = hours;
-        this.encoded = encode(this.hours, minutes, seconds, frames, type);
         updateData();
     }
 
     /**
-     * <table><caption>Formats</caption><tr><th>Type</th><th> Type value</th><th>Frame rate</th><th>Frames in second</th></tr><tr><td>Film</td><td>0</td><td>24</td><td>0-23</td></tr><tr><td>EBU</td><td>1</td><td>25</td><td>0-24</td></tr><tr><td>DF</td><td>2</td><td>29.97</td><td>0-29</td></tr><tr><td>SMTPE</td><td>3</td><td>30</td><td>0-30</td></tr></table>
+     * <table style="undefined;table-layout: fixed; width: 486px"><colgroup><col style="width: 120px"><col style="width: 107px"><col style="width: 101px"><col style="width: 158px"></colgroup><tr><th>Type</th><th> Type value</th><th>Frame rate</th><th>Frames in second</th></tr><tr><td>Film</td><td>0</td><td>24</td><td>0-23</td></tr><tr><td>EBU</td><td>1</td><td>25</td><td>0-24</td></tr><tr><td>DF</td><td>2</td><td>29.97</td><td>0-29</td></tr><tr><td>SMTPE</td><td>3</td><td>30</td><td>0-30</td></tr></table>
      * @return the frame type
      */
     public int getFrameType() {
@@ -227,12 +109,11 @@ public class ArtTimePacket extends ArtNetPacket {
     }
 
     /**
-     * <table><caption>Formats</caption><tr><th>Type</th><th> Type value</th><th>Frame rate</th><th>Frames in second</th></tr><tr><td>Film</td><td>0</td><td>24</td><td>0-23</td></tr><tr><td>EBU</td><td>1</td><td>25</td><td>0-24</td></tr><tr><td>DF</td><td>2</td><td>29.97</td><td>0-29</td></tr><tr><td>SMTPE</td><td>3</td><td>30</td><td>0-30</td></tr></table>
+     * <table style="undefined;table-layout: fixed; width: 486px"><colgroup><col style="width: 120px"><col style="width: 107px"><col style="width: 101px"><col style="width: 158px"></colgroup><tr><th>Type</th><th> Type value</th><th>Frame rate</th><th>Frames in second</th></tr><tr><td>Film</td><td>0</td><td>24</td><td>0-23</td></tr><tr><td>EBU</td><td>1</td><td>25</td><td>0-24</td></tr><tr><td>DF</td><td>2</td><td>29.97</td><td>0-29</td></tr><tr><td>SMTPE</td><td>3</td><td>30</td><td>0-30</td></tr></table>
      * @param type the frame type
      */
     public void setFrameType(int type) {
         this.type = type;
-        this.encoded = encode(hours, minutes, seconds, frames, this.type);
         updateData();
     }
     

--- a/src/main/java/ch/bildspur/artnet/packets/ArtTimePacket.java
+++ b/src/main/java/ch/bildspur/artnet/packets/ArtTimePacket.java
@@ -101,7 +101,7 @@ public class ArtTimePacket extends ArtNetPacket {
     }
 
     /**
-     * <table style="undefined;table-layout: fixed; width: 486px"><colgroup><col style="width: 120px"><col style="width: 107px"><col style="width: 101px"><col style="width: 158px"></colgroup><tr><th>Type</th><th> Type value</th><th>Frame rate</th><th>Frames in second</th></tr><tr><td>Film</td><td>0</td><td>24</td><td>0-23</td></tr><tr><td>EBU</td><td>1</td><td>25</td><td>0-24</td></tr><tr><td>DF</td><td>2</td><td>29.97</td><td>0-29</td></tr><tr><td>SMTPE</td><td>3</td><td>30</td><td>0-30</td></tr></table>
+     * <table><caption>Formats</caption><tr><th>Type</th><th> Type value</th><th>Frame rate</th><th>Frames in second</th></tr><tr><td>Film</td><td>0</td><td>24</td><td>0-23</td></tr><tr><td>EBU</td><td>1</td><td>25</td><td>0-24</td></tr><tr><td>DF</td><td>2</td><td>29.97</td><td>0-29</td></tr><tr><td>SMTPE</td><td>3</td><td>30</td><td>0-30</td></tr></table>
      * @return the frame type
      */
     public int getFrameType() {
@@ -109,7 +109,7 @@ public class ArtTimePacket extends ArtNetPacket {
     }
 
     /**
-     * <table style="undefined;table-layout: fixed; width: 486px"><colgroup><col style="width: 120px"><col style="width: 107px"><col style="width: 101px"><col style="width: 158px"></colgroup><tr><th>Type</th><th> Type value</th><th>Frame rate</th><th>Frames in second</th></tr><tr><td>Film</td><td>0</td><td>24</td><td>0-23</td></tr><tr><td>EBU</td><td>1</td><td>25</td><td>0-24</td></tr><tr><td>DF</td><td>2</td><td>29.97</td><td>0-29</td></tr><tr><td>SMTPE</td><td>3</td><td>30</td><td>0-30</td></tr></table>
+     * <table><caption>Formats</caption><tr><th>Type</th><th> Type value</th><th>Frame rate</th><th>Frames in second</th></tr><tr><td>Film</td><td>0</td><td>24</td><td>0-23</td></tr><tr><td>EBU</td><td>1</td><td>25</td><td>0-24</td></tr><tr><td>DF</td><td>2</td><td>29.97</td><td>0-29</td></tr><tr><td>SMTPE</td><td>3</td><td>30</td><td>0-30</td></tr></table>
      * @param type the frame type
      */
     public void setFrameType(int type) {


### PR DESCRIPTION
In the previous 4 months I have been working with timecode sending,
and I came to the conclusion that precise timing is not achievable by the
technique I implemented here (counting frames)
The proper way to have a precise timing is by counting the elapsed time
in milliseconds, and converting that directly into H:MM:SS:ff
An example of that can be found [here](https://github.com/MrExplode/Timecode/blob/07f9bbec58dfda845b7b219d97991581c8672a14/src/main/java/me/mrexplode/timecode/WorkerThread.java#L189) and [here](https://github.com/MrExplode/Timecode/blob/07f9bbec58dfda845b7b219d97991581c8672a14/src/main/java/me/mrexplode/timecode/Timecode.java#L60).

I also realized that the packet instance should not do any calculation whatsoever,
it should be done externally, by using your own methods to calculate the time.