### PR TITLE
Fix for Port Binding Conflicts in ArtNetClient and ArtNetServer

### DIFF
--- a/src/main/java/ch/bildspur/artnet/ArtNetClient.java
+++ b/src/main/java/ch/bildspur/artnet/ArtNetClient.java
@@ -49,8 +49,7 @@ public class ArtNetClient {
      * Start client with default arguments (listen on broadcast).
      */
     public void start() {
-        // use default network interface
-        this.start((InetAddress)null);
+        this.start(null, inputBuffer != null);
     }
 
     /**
@@ -60,7 +59,7 @@ public class ArtNetClient {
     public void start(String networkInterfaceAddress)
     {
         try {
-            this.start(InetAddress.getByName(networkInterfaceAddress));
+            this.start(InetAddress.getByName(networkInterfaceAddress), inputBuffer != null);
         } catch (UnknownHostException e) {
             e.printStackTrace();
         }
@@ -71,6 +70,15 @@ public class ArtNetClient {
      * @param networkInterfaceAddress Network interface address to listen to.
      */
     public void start(InetAddress networkInterfaceAddress) {
+        this.start(networkInterfaceAddress, inputBuffer != null);
+    }
+
+    /**
+     * Start client with specific network interface address and receiver mode.
+     * @param networkInterfaceAddress Network interface address to listen to.
+     * @param isReceiver If true, the client will bind to the specified port to receive data.
+     */
+    public void start(InetAddress networkInterfaceAddress, boolean isReceiver) {
         if (isRunning)
             return;
 
@@ -87,12 +95,20 @@ public class ArtNetClient {
                         }
                     });
 
-            server.start(networkInterfaceAddress);
+            server.start(networkInterfaceAddress, isReceiver);
 
             isRunning = true;
         } catch (SocketException | ArtNetException e) {
             e.printStackTrace();
         }
+    }
+
+    /**
+     * Start client with receiver mode.
+     * @param isReceiver If true, the client will bind to the specified port to receive data.
+     */
+    public void start(boolean isReceiver) {
+        this.start((InetAddress) null, isReceiver);
     }
 
     /**

--- a/src/main/java/ch/bildspur/artnet/ArtNetClient.java
+++ b/src/main/java/ch/bildspur/artnet/ArtNetClient.java
@@ -49,7 +49,8 @@ public class ArtNetClient {
      * Start client with default arguments (listen on broadcast).
      */
     public void start() {
-        this.start(null, inputBuffer != null);
+        // use default network interface
+        this.start((InetAddress)null);
     }
 
     /**
@@ -59,7 +60,7 @@ public class ArtNetClient {
     public void start(String networkInterfaceAddress)
     {
         try {
-            this.start(InetAddress.getByName(networkInterfaceAddress), inputBuffer != null);
+            this.start(InetAddress.getByName(networkInterfaceAddress));
         } catch (UnknownHostException e) {
             e.printStackTrace();
         }
@@ -70,15 +71,6 @@ public class ArtNetClient {
      * @param networkInterfaceAddress Network interface address to listen to.
      */
     public void start(InetAddress networkInterfaceAddress) {
-        this.start(networkInterfaceAddress, inputBuffer != null);
-    }
-
-    /**
-     * Start client with specific network interface address and receiver mode.
-     * @param networkInterfaceAddress Network interface address to listen to.
-     * @param isReceiver If true, the client will bind to the specified port to receive data.
-     */
-    public void start(InetAddress networkInterfaceAddress, boolean isReceiver) {
         if (isRunning)
             return;
 
@@ -95,7 +87,7 @@ public class ArtNetClient {
                         }
                     });
 
-            server.start(networkInterfaceAddress, isReceiver);
+            server.start(networkInterfaceAddress);
 
             isRunning = true;
         } catch (SocketException | ArtNetException e) {

--- a/src/main/java/ch/bildspur/artnet/ArtNetClient.java
+++ b/src/main/java/ch/bildspur/artnet/ArtNetClient.java
@@ -49,8 +49,7 @@ public class ArtNetClient {
      * Start client with default arguments (listen on broadcast).
      */
     public void start() {
-        // use default network interface
-        this.start((InetAddress)null);
+        this.start(null, inputBuffer != null);
     }
 
     /**
@@ -60,7 +59,7 @@ public class ArtNetClient {
     public void start(String networkInterfaceAddress)
     {
         try {
-            this.start(InetAddress.getByName(networkInterfaceAddress));
+            this.start(InetAddress.getByName(networkInterfaceAddress), inputBuffer != null);
         } catch (UnknownHostException e) {
             e.printStackTrace();
         }
@@ -71,6 +70,15 @@ public class ArtNetClient {
      * @param networkInterfaceAddress Network interface address to listen to.
      */
     public void start(InetAddress networkInterfaceAddress) {
+        this.start(networkInterfaceAddress, inputBuffer != null);
+    }
+
+    /**
+     * Start client with specific network interface address and receiver mode.
+     * @param networkInterfaceAddress Network interface address to listen to.
+     * @param isReceiver If true, the client will bind to the specified port to receive data.
+     */
+    public void start(InetAddress networkInterfaceAddress, boolean isReceiver) {
         if (isRunning)
             return;
 
@@ -87,7 +95,7 @@ public class ArtNetClient {
                         }
                     });
 
-            server.start(networkInterfaceAddress);
+            server.start(networkInterfaceAddress, isReceiver);
 
             isRunning = true;
         } catch (SocketException | ArtNetException e) {

--- a/src/main/java/ch/bildspur/artnet/ArtNetClient.java
+++ b/src/main/java/ch/bildspur/artnet/ArtNetClient.java
@@ -49,7 +49,7 @@ public class ArtNetClient {
      * Start client with default arguments (listen on broadcast).
      */
     public void start() {
-        this.start(null, inputBuffer != null);
+        this.start(null, true); // default to static binding (receiver mode)
     }
 
     /**

--- a/src/main/java/ch/bildspur/artnet/ArtNetServer.java
+++ b/src/main/java/ch/bildspur/artnet/ArtNetServer.java
@@ -158,10 +158,14 @@ public class ArtNetServer extends ArtNetNode implements Runnable {
     }
 
     public void start() throws SocketException, ArtNetException {
-        start(null);
+        start(null, true);
     }
 
     public void start(InetAddress networkAddress) throws SocketException, ArtNetException {
+        start(networkAddress, true);
+    }
+
+    public void start(InetAddress networkAddress, boolean isReceiver) throws SocketException, ArtNetException {
         if (broadCastAddress == null) {
             setBroadcastAddress(DEFAULT_BROADCAST_IP);
         }
@@ -170,12 +174,16 @@ public class ArtNetServer extends ArtNetNode implements Runnable {
             socket.setReuseAddress(true);
             socket.setBroadcast(true);
 
-            if (networkAddress == null)
-                networkAddress = socket.getLocalAddress();
+            if (isReceiver) {
+                if (networkAddress == null)
+                    networkAddress = socket.getLocalAddress();
 
-            socket.bind(new InetSocketAddress(networkAddress, port));
+                socket.bind(new InetSocketAddress(networkAddress, port));
+                logger.info("Art-Net server started at: " + networkAddress.getHostAddress() + ":" + port);
+            } else {
+                logger.info("Art-Net server started as sender using ephemeral port.");
+            }
 
-            logger.info("Art-Net server started at: " + networkAddress.getHostAddress() + ":" + port);
             for (ArtNetServerListener l : listeners) {
                 l.artNetServerStarted(this);
             }

--- a/src/main/java/ch/bildspur/artnet/ArtNetServer.java
+++ b/src/main/java/ch/bildspur/artnet/ArtNetServer.java
@@ -181,7 +181,7 @@ public class ArtNetServer extends ArtNetNode implements Runnable {
                 socket.bind(new InetSocketAddress(networkAddress, port));
                 logger.info("Art-Net server started at: " + networkAddress.getHostAddress() + ":" + port);
             } else {
-                logger.info("Art-Net server started at: " + networkAddress.getHostAddress() + ":" + port + " (ephemeral mode)");
+                logger.info("Art-Net server started as sender using ephemeral port.");
             }
 
             for (ArtNetServerListener l : listeners) {

--- a/src/main/java/ch/bildspur/artnet/ArtNetServer.java
+++ b/src/main/java/ch/bildspur/artnet/ArtNetServer.java
@@ -181,7 +181,7 @@ public class ArtNetServer extends ArtNetNode implements Runnable {
                 socket.bind(new InetSocketAddress(networkAddress, port));
                 logger.info("Art-Net server started at: " + networkAddress.getHostAddress() + ":" + port);
             } else {
-                logger.info("Art-Net server started as sender using ephemeral port.");
+                logger.info("Art-Net server started at: " + networkAddress.getHostAddress() + ":" + port + " (ephemeral mode)");
             }
 
             for (ArtNetServerListener l : listeners) {


### PR DESCRIPTION
This PR addresses an issue (#26) where the `ArtNetClient` and `ArtNetServer` classes were causing port binding conflicts when used as a sender and receiver simultaneously on the same machine. By introducing a new parameter to control whether the client/server should bind to a port or use an ephemeral port, we resolve the conflicts and improve the flexibility of the library.

**Changes Made:**

1. **ArtNetClient.java:**
   - Added a new `start(boolean isReceiver)` method to allow specifying the mode (sender or receiver) directly.
   - Modified existing `start` methods to preserve backward compatibility and default to using the input buffer to determine the receiver mode.

2. **ArtNetServer.java:**
   - Updated the `start` method to accept a `boolean isReceiver` parameter to control whether to bind to the specified port or use an ephemeral port.

**Testing:**

- Tested with Processing 4 application to ensure the `ArtNetClient` can be started as a sender using `artnet.start(false)`.
- Verified that no port binding conflicts occur when running multiple instances as both sender and receiver on the same machine.

**Documentation:**

**Usage Example:**

To start an `ArtNetClient` as a sender (without port binding):

```java
import ch.bildspur.artnet.*;

ArtNetClient artnet;
byte[] dmxData = new byte[512];

void setup() {
  size(500, 250);
  
  colorMode(HSB, 360, 100, 100);
  textAlign(CENTER, CENTER);
  textSize(20);

  // create artnet client without buffer (no receiving needed)
  artnet = new ArtNetClient(null);
  artnet.start(false); // false indicates it is a sender
}

void draw() {
  // create color
  int c = color(frameCount % 360, 80, 100);

  background(c);

  // fill dmx array
  dmxData[0] = (byte) red(c);
  dmxData[1] = (byte) green(c);
  dmxData[2] = (byte) blue(c);

  // send dmx to localhost
  artnet.unicastDmx("127.0.0.1", 0, 0, dmxData);

  // show values
  text("R: " + (int)red(c) + " Green: " + (int)green(c) + " Blue: " + (int)blue(c), width / 2, height / 2);
}
```

**Backward Compatibility:**

- The existing methods are preserved to maintain backward compatibility.
- The new parameter defaults to `true` for receiver mode when not specified.

**Conclusion:**

These changes improve the flexibility and usability of the `artnet4j` library by resolving port binding conflicts and allowing users to specify the mode of the client/server.

I really needed this behavior for my own application so I didn't go too deeply into an optimal fix. A better solution may be to infer if the connection is a reciever or sender somehow, but this was beyond the limits of what I had time for and to be honest my Java is not that great. 

If the maintainers feel like this solution is adequate though, great!

All the best,

-T